### PR TITLE
Use working dir instead of file dir

### DIFF
--- a/bin/ocular
+++ b/bin/ocular
@@ -5,6 +5,8 @@ call_user_func(function() {
     require_once call_user_func(function() {
         if (is_file($file = __DIR__.'/../vendor/autoload.php')) {
             return $file;
+        } elseif (is_file($file = getcwd().'/vendor/autoload.php')) {
+        	return $file;
         }
 
         throw new \LogicException('Could not locate autoload.php. Did you forget to install vendors using "composer install"?');


### PR DESCRIPTION
`__DIR__` is the directory of the current file. If you run this file like that:

``` shell
composer require scrutinizer/ocular:~1.0.0
vendor/bin/ocular code-coverage:upload .....
```

It would not find the `autoload.php` file of Composer. This is because Composer symlinks `bin/ocular` to `vendor/bin/ocular`. This messes up with the path to `autoload.php`.

---

I don't think this would be a perfect solution, this is just how I got it work. If this would screw up some other workflow, please let me know. I guess you have not considered this use case.
