### PR TITLE
Cleaned the logic to find the autoloader

### DIFF
--- a/bin/ocular
+++ b/bin/ocular
@@ -5,7 +5,9 @@ call_user_func(function() {
     require_once call_user_func(function() {
         if (is_file($file = __DIR__.'/../vendor/autoload.php')) {
             return $file;
-        } elseif (is_file($file = getcwd().'/vendor/autoload.php')) {
+        }
+        
+        if (is_file($file = __DIR__.'/../../../autoload.php')) {
         	return $file;
         }
 


### PR DESCRIPTION
When installing ocular as a dependency of the project, the autoload file should be looked for based on the path where ocular gets installed.
Relying on getcwd would limit the support to projects using the default name for the vendor folder and calls done from the root of the project

This is a better fix than https://github.com/scrutinizer-ci/ocular/pull/4 by identifying the real issue
