### PR TITLE
Expanded qualified name parser to allow tokenized git urls

### DIFF
--- a/src/Scrutinizer/Ocular/Util/RepositoryIntrospector.php
+++ b/src/Scrutinizer/Ocular/Util/RepositoryIntrospector.php
@@ -48,7 +48,7 @@ class RepositoryIntrospector
 
         $patterns = array(
             '#^origin\s+(?:git@|(?:git|https?)://)([^:/]+)(?:/|:)([^/]+)/([^/\s]+?)(?:\.git)?(?:\s|\n)#m',
-            '#^[^\s]+\s+(?:git@|(?:git|https?)://)([^:/]+)(?:/|:)([^/]+)/([^/\s]+?)(?:\.git)?(?:\s|\n)#m',
+            '#^[^\s]+\s+(?:[^\s]+@|(?:git|https?)://)([^:/]+)(?:/|:)([^/]+)/([^/\s]+?)(?:\.git)?(?:\s|\n)#m',
         );
 
         foreach ($patterns as $pattern) {

--- a/tests/Scrutinizer/Tests/Ocular/Util/RepositoryIntrospectorTest.php
+++ b/tests/Scrutinizer/Tests/Ocular/Util/RepositoryIntrospectorTest.php
@@ -11,10 +11,22 @@ class RepositoryInspectorTest extends \PHPUnit_Framework_TestCase
 {
     private $tmpDirs = array();
 
-    public function testGetQualifiedName()
+    public function repoUrlProvider()
+    {
+        return [
+            ['git@github.com:schmittjoh/metadata.git'],
+            ['https://github.com/schmittjoh/metadata.git'],
+            ['https://ashon-ikon:2ae3578bfd30cbc9bb58861cf9f0fa742259cdb8@github.com/schmittjoh/metadata.git'],
+        ];
+    }
+
+    /**
+     * @dataProvider repoUrlProvider
+     */
+    public function testGetQualifiedName($url)
     {
         $tmpDir = $this->getTempDir();
-        $this->installRepository('https://github.com/schmittjoh/metadata.git', $tmpDir);
+        $this->installRepository($url, $tmpDir);
 
         $introspector = new RepositoryIntrospector($tmpDir);
         $this->assertEquals('g/schmittjoh/metadata', $introspector->getQualifiedName());


### PR DESCRIPTION
The current parser regex does not accept tokenized git remote URLs. This pull request seeks to expand the pattern.
### Previous Scenarios
|URL|Remark|
|------------|----------------|
|git@github.com:schmittjoh/metadata.git| Worked|
|https://github.com/schmittjoh/metadata.git| Worked|
|https://schmittjoh:2ae3578bfd30cbc9bb58861cf9f0fa742259cdb8@github.com/schmittjoh/metadata.git|Failed|

### Current Scenarios
|URL|Remark|
|------------|----------------|
|git@github.com:schmittjoh/metadata.git| Worked|
|https://github.com/schmittjoh/metadata.git| Worked|
|https://schmittjoh:2ae3578bfd30cbc9bb58861cf9f0fa742259cdb8@github.com/schmittjoh/metadata.git|Works|

Just by altering the regular expression from
```
#^[^\s]+\s+(?:git@|(?:git|https?)://)([^:/]+)(?:/|:)([^/]+)/([^/\s]+?)(?:\.git)?(?:\s|\n)#m
```
to
```
#^[^\s]+\s+(?:[^\s]+@|(?:git|https?)://)([^:/]+)(?:/|:)([^/]+)/([^/\s]+?)(?:\.git)?(?:\s|\n)#m
```