### PR TITLE
Fix getBasePath() on Windows

### DIFF
--- a/src/Scrutinizer/Ocular/Command/CodeCoverage/UploadCommand.php
+++ b/src/Scrutinizer/Ocular/Command/CodeCoverage/UploadCommand.php
@@ -102,7 +102,7 @@ class UploadCommand extends Command
     {
         $dir = getcwd();
         while ( ! empty($dir)) {
-            if (is_dir($dir.'/.git')) {
+            if (is_dir($dir.DIRECTORY_SEPARATOR.'.git')) {
                 return $dir;
             }
 

--- a/src/Scrutinizer/Ocular/Command/CodeCoverage/UploadCommand.php
+++ b/src/Scrutinizer/Ocular/Command/CodeCoverage/UploadCommand.php
@@ -93,7 +93,7 @@ class UploadCommand extends Command
     private function getCoverageData($file)
     {
         $content = file_get_contents($file);
-        $content = str_replace($this->getBasePath(), '{scrutinizer_project_base_path}', $content);
+        $content = str_replace($this->getBasePath(), '{scrutinizer_project_base_path}/', $content);
 
         return $content;
     }
@@ -103,7 +103,7 @@ class UploadCommand extends Command
         $dir = getcwd();
         while ( ! empty($dir)) {
             if (is_dir($dir.DIRECTORY_SEPARATOR.'.git')) {
-                return $dir;
+                return $dir.DIRECTORY_SEPARATOR;
             }
 
             $dir = dirname($dir);


### PR DESCRIPTION
getBasePath() could not determine .git directory because Windows uses \.