### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "symfony/filesystem": "~2.0|~3.0",
-        "phpunit/phpunit": "^4.8.0"
+        "phpunit/phpunit": "^4.8.35"
     },
     "license" : "Apache-2.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "73b54b185560afe269f39a836556df72",
+    "content-hash": "42708a0f706a3758f8d5ad9a12f50ea6",
     "packages": [
         {
             "name": "doctrine/annotations",

--- a/tests/Scrutinizer/Tests/Ocular/Util/RepositoryIntrospectorTest.php
+++ b/tests/Scrutinizer/Tests/Ocular/Util/RepositoryIntrospectorTest.php
@@ -2,12 +2,13 @@
 
 namespace Scrutinizer\Tests\Ocular\Util;
 
+use PHPUnit\Framework\TestCase;
 use Scrutinizer\Ocular\Util\RepositoryIntrospector;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
-class RepositoryInspectorTest extends \PHPUnit_Framework_TestCase
+class RepositoryInspectorTest extends TestCase
 {
     private $tmpDirs = array();
 


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.