### PR TITLE
Add support for PHP 8 (and Symfony 5 process)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/console": "^2.1.0|~3.0|~4.0|~5.0",
         "symfony/process": "~2.3|~3.0|~4.0|~5.0",
         "phpoption/phpoption": "~1.0",
-        "guzzlehttp/guzzle": "~6.3",
+        "guzzlehttp/guzzle": "~6.3|^7.0",
         "jms/serializer": "^1.0.0"
     },
     "require-dev": {

--- a/src/Scrutinizer/Ocular/Util/RepositoryIntrospector.php
+++ b/src/Scrutinizer/Ocular/Util/RepositoryIntrospector.php
@@ -19,7 +19,7 @@ class RepositoryIntrospector
 
     public function getCurrentRevision()
     {
-        $proc = new Process('git rev-parse HEAD', $this->dir);
+        $proc = new Process(['git', 'rev-parse', 'HEAD'], $this->dir);
         if (0 !== $proc->run()) {
             throw new ProcessFailedException($proc);
         }
@@ -29,7 +29,7 @@ class RepositoryIntrospector
 
     public function getCurrentParents()
     {
-        $proc = new Process('git log --pretty="%P" -n1 HEAD', $this->dir);
+        $proc = new Process(['git', 'log', '--pretty=%P', '-n1', 'HEAD'], $this->dir);
         if (0 !== $proc->run()) {
             throw new ProcessFailedException($proc);
         }
@@ -39,7 +39,7 @@ class RepositoryIntrospector
 
     public function getQualifiedName()
     {
-        $proc = new Process('git remote -v', $this->dir);
+        $proc = new Process(['git', 'remote', '-v'], $this->dir);
         if (0 !== $proc->run()) {
             throw new ProcessFailedException($proc);
         }


### PR DESCRIPTION
Fixes https://github.com/scrutinizer-ci/ocular/issues/51 and https://github.com/scrutinizer-ci/ocular/issues/47

Guzzle 7.2.0 added support for PHP 8, seee https://github.com/guzzle/guzzle/blob/7.2.0/CHANGELOG.md#720---2020-10-10

Included https://github.com/scrutinizer-ci/ocular/pull/49 in my fork, because we also needed that fix our project.