### PR TITLE
Specify supported PHP-Version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         }
     },
     "require": {
+        "php": ">=7.0"
         "symfony/console": "^2.1.0|~3.0|~4.0|~5.0|^6.0",
         "symfony/process": "~2.3|~3.0|~4.0|~5.0|^6.0",
         "phpoption/phpoption": "~1.0",


### PR DESCRIPTION
Installing the package globally does cause the wrong version to be installed since composer.json is missing `php` from the require section.